### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# Part of CMake configuration for lexertl library
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file licence_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+cmake_minimum_required (VERSION 3.5)
+project(lexertl VERSION 0.1.0)
+
+# Define project
+add_library(lexertl INTERFACE)
+target_include_directories(lexertl INTERFACE 
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:include>
+)
+
+if (BUILD_TESTING)
+	enable_testing()
+	add_subdirectory(tests)
+endif()
+
+# Generate install
+include(GNUInstallDirs)
+
+install(TARGETS lexertl EXPORT lexertlTargets
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(DIRECTORY include/lexertl DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT lexertlTargets
+	FILE lexertlTargets.cmake
+	NAMESPACE lexertl::
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lexertl
+)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("lexertlConfigVersion.cmake"
+	VERSION ${lexertl_VERSION}
+	COMPATIBILITY SameMajorVersion
+)
+install(FILES "lexertlConfig.cmake" "${CMAKE_CURRENT_BINARY_DIR}/lexertlConfigVersion.cmake"
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/lexertl
+)
+

--- a/lexertlConfig.cmake
+++ b/lexertlConfig.cmake
@@ -1,0 +1,2 @@
+include(CMakeFindDependencyMacro)
+include("${CMAKE_CURRENT_LIST_DIR}/lexertlTargets.cmake")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+#
+# Part of CMake configuration for lexertl library
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file licence_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+add_subdirectory(fail_tests)
+add_subdirectory(include_test)

--- a/tests/include_test/CMakeLists.txt
+++ b/tests/include_test/CMakeLists.txt
@@ -1,0 +1,59 @@
+#
+# Part of CMake configuration for lexertl library
+#
+# Copyright (c) 2013 Mateusz Loskot <mateusz@loskot.net>
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file licence_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+include_directories(.)
+
+add_executable(lexertl_include_tests
+	# bitvector.cpp
+	blocks.cpp
+	charset.cpp
+	char_traits.cpp
+	debug.cpp
+	dot.cpp
+	end_node.cpp
+	enum_operator.cpp
+	enums.cpp
+	equivset.cpp
+	generate_cpp.cpp
+	generator.cpp
+	internals.cpp
+	iteration_node.cpp
+	iterator.cpp
+	leaf_node.cpp
+	lookup.cpp
+	match_results.cpp
+	memory_file.cpp
+	narrow.cpp
+	node.cpp
+	observer_ptr.cpp
+	parser.cpp
+	# ptr_list.cpp
+	# ptr_map.cpp
+	# ptr_stack.cpp
+	# ptr_vector.cpp
+	replace.cpp
+	re_token.cpp
+	re_tokeniser.cpp
+	re_tokeniser_helper.cpp
+	re_tokeniser_state.cpp
+	rules.cpp
+	runtime_error.cpp
+	scripts.cpp
+	selection_node.cpp
+	sequence_node.cpp
+	serialise.cpp
+	sm_to_csm.cpp
+	sm_traits.cpp
+	state_machine.cpp
+	stream_num.cpp
+	stream_shared_iterator.cpp
+	string_token.cpp
+	unicode.cpp
+	utf_iterators.cpp
+	main.cpp)
+target_link_libraries(lexertl_include_tests PRIVATE lexertl)


### PR DESCRIPTION
I’m not very opinionated about what this should look like, but it would at least be nice to be able to build and run the tests using some kind of build system. This PR pretty much just copies in the CMake support from https://github.com/BenHanson/lexertl14. The only change is that there are no examples to build.