### PR TITLE
Support building the examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ target_include_directories(lexertl INTERFACE
 	$<INSTALL_INTERFACE:include>
 )
 
+if (BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif()
+
 if (BUILD_TESTING)
 	enable_testing()
 	add_subdirectory(tests)

--- a/examples/date_test/main.cpp
+++ b/examples/date_test/main.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <fstream>
 #include <lexertl/generator.hpp>
 #include <lexertl/lookup.hpp>
@@ -5,7 +6,9 @@
 
 int main(int /*argc*/, char** /*argv*/)
 {
-    lexertl::rules rules_(lexertl::icase | lexertl::dot_not_newline);
+    lexertl::rules rules_(
+        static_cast<std::size_t>(lexertl::regex_flags::icase) |
+        static_cast<std::size_t>(lexertl::regex_flags::dot_not_newline));
     lexertl::state_machine sm_;
     std::ifstream if_("datetest.txt");
     lexertl::stream_shared_iterator iter_(if_);

--- a/examples/unicode/main.cpp
+++ b/examples/unicode/main.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <fstream>
 #include <lexertl/generator.hpp>
 #include <iomanip>
@@ -39,7 +40,8 @@ void test_unicode()
     i = *++u16iter_; // 0xd7ff
 
     // Not all compilers have char32_t, so use int for now
-    lexertl::basic_rules<char, int> rules_(lexertl::icase);
+    lexertl::basic_rules<char, int> rules_(
+        static_cast<std::size_t>(lexertl::regex_flags::icase));
     lexertl::basic_state_machine<int> sm_;
     const int in_[] = {0x393, ' ', 0x393, 0x398, ' ', 0x398,
         '1', ' ', 'i', 'd', 0x41f, 0};


### PR DESCRIPTION
Add the necessary conditional to the top-level `CMakeLists.txt`, and adapt a couple of examples to deal with the conversion of `regex_flags` from `enum` to `enum class` in https://github.com/BenHanson/lexertl14/commit/7718de2511ecde6fa8794697cf20e22772810cc1. (The same change is needed in `lexertl14` for its examples to build….)