### PR TITLE
Ensure examples and tests include <iostream> for std::cout

### DIFF
--- a/examples/date_test/main.cpp
+++ b/examples/date_test/main.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iostream>
 #include <lexertl/generator.hpp>
 #include <lexertl/lookup.hpp>
 #include <lexertl/stream_shared_iterator.hpp>

--- a/examples/ocaml/main.cpp
+++ b/examples/ocaml/main.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <lexertl/generator.hpp>
 #include <lexertl/lookup.hpp>
 

--- a/examples/unicode/main.cpp
+++ b/examples/unicode/main.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iostream>
 #include <lexertl/generator.hpp>
 #include <iomanip>
 #include <lexertl/lookup.hpp>

--- a/examples/wc/main.cpp
+++ b/examples/wc/main.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 //#include <lexertl/debug.hpp>
 #include <lexertl/generator.hpp>
 #include <lexertl/lookup.hpp>

--- a/tests/fail_tests/fail_tests.cpp
+++ b/tests/fail_tests/fail_tests.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#include <iostream>
 #include <lexertl/generator.hpp>
 
 const char *error_regexes_[] =

--- a/tests/fail_tests/main.cpp
+++ b/tests/fail_tests/main.cpp
@@ -3,6 +3,7 @@
 
 #include "stdafx.h"
 
+#include <iostream>
 #include "fail_tests.h"
 #include <lexertl/parser/tokeniser/re_tokeniser.hpp>
 


### PR DESCRIPTION
Fixes compile errors with `-DBUILD_EXAMPLES=ON` and/or `-DBUILD_TESTING=ON` since some of the indirect includes were rearranged in 1.2.4, e.g.:

```
/home/ben/src/forks/lexertl17/examples/date_test/main.cpp: In function ‘int main(int, char**)’:
/home/ben/src/forks/lexertl17/examples/date_test/main.cpp:113:18: error: ‘cout’ is not a member of ‘std’
  113 |             std::cout << "Long:\n" <<
      |                  ^~~~
/home/ben/src/forks/lexertl17/examples/date_test/main.cpp:5:1: note: ‘std::cout’ is defined in header ‘<iostream>’; this is probably fixable by adding ‘#include <iostream>’
    4 | #include <lexertl/stream_shared_iterator.hpp>
  +++ |+#include <iostream>
    5 | 
/home/ben/src/forks/lexertl17/examples/date_test/main.cpp:124:18: error: ‘cout’ is not a member of ‘std’
  124 |             std::cout << "Short:\n" <<
      |                  ^~~~
/home/ben/src/forks/lexertl17/examples/date_test/main.cpp:124:18: note: ‘std::cout’ is defined in header ‘<iostream>’; this is probably fixable by adding ‘#include <iostream>’
gmake[2]: *** [examples/date_test/CMakeFiles/lexertl_date_test.dir/build.make:79: examples/date_test/CMakeFiles/lexertl_date_test.dir/main.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:318: examples/date_test/CMakeFiles/lexertl_date_test.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```